### PR TITLE
in the ubi's json there is a change of name from nakk to nokk

### DIFF
--- a/r6sapi/operators.py
+++ b/r6sapi/operators.py
@@ -177,7 +177,7 @@ OperatorStatisticNames = {
     "MOZZIE": "Drones Hacked",
     "GRIDLOCK": "Trax Deployed",
     "WARDEN": "Flashes Resisted",
-    "NAKK": "Observation tools deceived",
+    "NOKK": "Observation tools deceived",
     "AMARU": "Distance Reeled",
     "GOYO": "Volcans Detonated",
     "KALI": "Gadgets destroyed with explosive lance",


### PR DESCRIPTION
json with ee566014 code (void edge):
`"nakk": { "id":"nakk",
                "category":"atk",
                "name":{"oasisId":"299657"},
                [...]
               },`

json with 269788a7 code (shadow legacy):
`"nokk": { "id":"nokk",
                "category":"atk",
                "name":{"oasisId":"299657"},
                [...]
                }`