### PR TITLE
Updated gettingstarted.rst to match quick example code from README.

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -13,16 +13,16 @@ Quick Example
 
     import asyncio
     import r6sapi as api
-    
-    @asyncio.coroutine
-    def run():
+
+    async def run():
         auth = api.Auth("email", "password")
-      
-        player = yield from auth.get_player("billy_yoyo", api.Platforms.UPLAY)
-        operator = yield from player.get_operator("sledge")
-		
+
+        player = await auth.get_player("billy_yoyo", api.Platforms.UPLAY)
+        operator = await player.get_operator("sledge")
         print(operator.kills)
-        
+
+        await auth.close()
+
     asyncio.get_event_loop().run_until_complete(run())
 
 


### PR DESCRIPTION
"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead. Making this change seems to be what the README now reflects.